### PR TITLE
Refactor to replace "subspaceName" with a Subspace class

### DIFF
--- a/libraries/rush-lib/src/api/ApprovedPackagesPolicy.ts
+++ b/libraries/rush-lib/src/api/ApprovedPackagesPolicy.ts
@@ -84,7 +84,7 @@ export class ApprovedPackagesPolicy {
 
     // Load browser-approved-packages.json
     const browserApprovedPackagesPath: string = path.join(
-      rushConfiguration.getCommonRushConfigFolder(),
+      rushConfiguration.commonRushConfigFolder,
       RushConstants.browserApprovedPackagesFilename
     );
     this.browserApprovedPackages = new ApprovedPackagesConfiguration(browserApprovedPackagesPath);
@@ -92,7 +92,7 @@ export class ApprovedPackagesPolicy {
 
     // Load nonbrowser-approved-packages.json
     const nonbrowserApprovedPackagesPath: string = path.join(
-      rushConfiguration.getCommonRushConfigFolder(),
+      rushConfiguration.commonRushConfigFolder,
       RushConstants.nonbrowserApprovedPackagesFilename
     );
     this.nonbrowserApprovedPackages = new ApprovedPackagesConfiguration(nonbrowserApprovedPackagesPath);

--- a/libraries/rush-lib/src/api/BuildCacheConfiguration.ts
+++ b/libraries/rush-lib/src/api/BuildCacheConfiguration.ts
@@ -163,7 +163,7 @@ export class BuildCacheConfiguration {
    * Gets the absolute path to the build-cache.json file in the specified rush workspace.
    */
   public static getBuildCacheConfigFilePath(rushConfiguration: RushConfiguration): string {
-    return path.resolve(rushConfiguration.getCommonRushConfigFolder(), RushConstants.buildCacheFilename);
+    return path.resolve(rushConfiguration.commonRushConfigFolder, RushConstants.buildCacheFilename);
   }
 
   private static async _loadAsync(

--- a/libraries/rush-lib/src/api/CobuildConfiguration.ts
+++ b/libraries/rush-lib/src/api/CobuildConfiguration.ts
@@ -105,7 +105,7 @@ export class CobuildConfiguration {
   }
 
   public static getCobuildConfigFilePath(rushConfiguration: RushConfiguration): string {
-    return `${rushConfiguration.getCommonRushConfigFolder()}/${RushConstants.cobuildFilename}`;
+    return `${rushConfiguration.commonRushConfigFolder}/${RushConstants.cobuildFilename}`;
   }
 
   private static async _loadAsync(

--- a/libraries/rush-lib/src/api/LastInstallFlag.ts
+++ b/libraries/rush-lib/src/api/LastInstallFlag.ts
@@ -8,6 +8,7 @@ import { FileSystem, JsonFile, type JsonObject, Path } from '@rushstack/node-cor
 import type { PackageManagerName } from './packageManager/PackageManager';
 import type { RushConfiguration } from './RushConfiguration';
 import { objectsAreDeepEqual } from '../utilities/objectUtilities';
+import type { Subspace } from './Subspace';
 
 export const LAST_INSTALL_FLAG_FILE_NAME: string = 'last-install.flag';
 
@@ -162,7 +163,7 @@ export class LastInstallFlagFactory {
    */
   public static getCommonTempFlag(
     rushConfiguration: RushConfiguration,
-    subspaceName: string | undefined,
+    subspace: Subspace,
     extraState: Record<string, string> = {}
   ): LastInstallFlag {
     const currentState: JsonObject = {
@@ -180,6 +181,6 @@ export class LastInstallFlagFactory {
       }
     }
 
-    return new LastInstallFlag(rushConfiguration.getCommonTempFolder(subspaceName), currentState);
+    return new LastInstallFlag(subspace.getSubspaceTempFolder(), currentState);
   }
 }

--- a/libraries/rush-lib/src/api/LastLinkFlag.ts
+++ b/libraries/rush-lib/src/api/LastLinkFlag.ts
@@ -3,7 +3,7 @@
 
 import { LastInstallFlag } from './LastInstallFlag';
 import { type JsonObject, JsonFile, InternalError } from '@rushstack/node-core-library';
-import type { RushConfiguration } from './RushConfiguration';
+import type { Subspace } from './Subspace';
 
 export const LAST_LINK_FLAG_FILE_NAME: string = 'last-link.flag';
 
@@ -57,10 +57,7 @@ export class LastLinkFlagFactory {
    *
    * @internal
    */
-  public static getCommonTempFlag(
-    rushConfiguration: RushConfiguration,
-    subspaceName?: string | undefined
-  ): LastLinkFlag {
-    return new LastLinkFlag(rushConfiguration.getCommonTempFolder(subspaceName), {});
+  public static getCommonTempFlag(subspace: Subspace): LastLinkFlag {
+    return new LastLinkFlag(subspace.getSubspaceTempFolder(), {});
   }
 }

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -12,6 +12,7 @@ import { RushConstants } from '../logic/RushConstants';
 import { PackageNameParsers } from './PackageNameParsers';
 import { DependencySpecifier, DependencySpecifierType } from '../logic/DependencySpecifier';
 import { SaveCallbackPackageJsonEditor } from './SaveCallbackPackageJsonEditor';
+import type { Subspace } from './Subspace';
 
 /**
  * This represents the JSON data object for a project entry in the rush.json configuration file.
@@ -50,6 +51,11 @@ export interface IRushConfigurationProjectOptions {
    * If specified, validate project tags against this list.
    */
   allowedProjectTags: Set<string> | undefined;
+
+  /**
+   * The containing subspace.
+   */
+  subspace: Subspace;
 }
 
 /**
@@ -105,6 +111,12 @@ export class RushConfigurationProject {
    * The Rush configuration for the monorepo that the project belongs to.
    */
   public readonly rushConfiguration: RushConfiguration;
+
+  /**
+   * Returns the subspace name that a project belongs to.
+   * If subspaces is not enabled, returns the default subspace.
+   */
+  public readonly subspace: Subspace;
 
   /**
    * The review category name, or undefined if no category was assigned.
@@ -186,17 +198,13 @@ export class RushConfigurationProject {
   public readonly tags: ReadonlySet<string>;
 
   /**
-   * Returns the name of the subspace that this project belongs to, as assigned by the `"subspaceName"`
-   * property in `rush.json`.
-   *
-   * @remarks
-   * If the Rush subspaces feature is disabled, the value is still return.
-   * When the Rush subspaces feature is enabled, an undefined `subspaceName` specifies that
-   * the project belongs to the default subspace (whose name is `"default"`).
+   * Returns the subspace name specified in the `"subspaceName"` field in `rush.json`.
+   * Note that this field may be undefined, if the `default` subspace is being used,
+   * and this field may be ignored if the subspaces feature is disabled.
    *
    * @beta
    */
-  public readonly subspaceName: string | undefined;
+  public readonly configuredSubspaceName: string | undefined;
 
   /** @internal */
   public constructor(options: IRushConfigurationProjectOptions) {
@@ -339,7 +347,8 @@ export class RushConfigurationProject {
       this.tags = new Set(projectJson.tags);
     }
 
-    this.subspaceName = projectJson.subspaceName;
+    this.configuredSubspaceName = projectJson.subspaceName;
+    this.subspace = options.subspace;
   }
 
   /**

--- a/libraries/rush-lib/src/api/Subspace.ts
+++ b/libraries/rush-lib/src/api/Subspace.ts
@@ -1,0 +1,271 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'path';
+
+import { FileSystem } from '@rushstack/node-core-library';
+import type { RushConfiguration } from './RushConfiguration';
+import type { RushConfigurationProject } from './RushConfigurationProject';
+import { EnvironmentConfiguration } from './EnvironmentConfiguration';
+import { RushConstants } from '../logic/RushConstants';
+import { CommonVersionsConfiguration } from './CommonVersionsConfiguration';
+import { RepoStateFile } from '../logic/RepoStateFile';
+import type { PnpmPackageManager } from './packageManager/PnpmPackageManager';
+
+/**
+ * The allowed naming convention for subspace names.
+ * Allows for names to be formed of letters, numbers, and hyphens (-)
+ */
+export const SUBSPACE_NAME_REGEXP: RegExp = /^[a-z0-9]*([-+_a-z0-9]+)*$/;
+
+/**
+ * @internal
+ */
+export interface ISubspaceOptions {
+  subspaceName: string;
+  rushConfiguration: RushConfiguration;
+  splitWorkspaceCompatibility: boolean;
+}
+
+interface ISubspaceDetail {
+  subspaceConfigFolder: string;
+  subspaceTempFolder: string;
+  tempShrinkwrapFilename: string;
+  tempShrinkwrapPreinstallFilename: string;
+}
+
+/**
+ * This represents the subspace configurations for a repository, based on the "subspaces.json"
+ * configuration file.
+ * @public
+ */
+export class Subspace {
+  public readonly subspaceName: string;
+  private readonly _rushConfiguration: RushConfiguration;
+  private readonly _projects: RushConfigurationProject[] = [];
+  private readonly _splitWorkspaceCompatibility: boolean;
+  private _commonVersionsConfiguration: CommonVersionsConfiguration | undefined = undefined;
+
+  private _detail: ISubspaceDetail | undefined;
+
+  public constructor(options: ISubspaceOptions) {
+    this.subspaceName = options.subspaceName;
+    this._rushConfiguration = options.rushConfiguration;
+    this._splitWorkspaceCompatibility = options.splitWorkspaceCompatibility;
+  }
+
+  /**
+   * Returns the list of projects belonging to this subspace.
+   * @beta
+   */
+  public getProjects(): RushConfigurationProject[] {
+    return this._projects;
+  }
+
+  private _ensureDetail(): ISubspaceDetail {
+    if (!this._detail) {
+      const rushConfiguration: RushConfiguration = this._rushConfiguration;
+      let subspaceConfigFolder: string;
+
+      if (rushConfiguration.subspacesFeatureEnabled) {
+        // If this subspace doesn't have a configuration folder, check if it is in the project folder itself
+        // if the splitWorkspaceCompatibility option is enabled in the subspace configuration
+
+        // Example: C:\MyRepo\common\config\subspaces\my-subspace
+        const standardSubspaceConfigFolder: string = `${rushConfiguration.commonFolder}/config/subspaces/${this.subspaceName}`;
+
+        subspaceConfigFolder = standardSubspaceConfigFolder;
+
+        if (this._splitWorkspaceCompatibility && this.subspaceName.startsWith('split-')) {
+          if (FileSystem.exists(standardSubspaceConfigFolder + '/pnpm-lock.yaml')) {
+            throw new Error(
+              `The split workspace subspace "${this.subspaceName}" cannot use a common/config folder: ` +
+                standardSubspaceConfigFolder
+            );
+          }
+
+          if (this._projects.length !== 1) {
+            throw new Error(
+              `The split workspace subspace "${this.subspaceName}" contains ${this._projects.length}` +
+                ` projects; there must be exactly one project.`
+            );
+          }
+          const project: RushConfigurationProject = this._projects[0];
+          subspaceConfigFolder = project.projectFolder;
+        }
+
+        if (!FileSystem.exists(subspaceConfigFolder)) {
+          throw new Error(
+            `The configuration folder for the "${this.subspaceName}" subspace does not exist: ` +
+              subspaceConfigFolder
+          );
+        }
+      } else {
+        // Example: C:\MyRepo\common\config\rush
+        subspaceConfigFolder = rushConfiguration.commonRushConfigFolder;
+      }
+
+      // Example: C:\MyRepo\common\temp
+      const commonTempFolder: string =
+        EnvironmentConfiguration.rushTempFolderOverride || rushConfiguration.commonTempFolder;
+
+      let subspaceTempFolder: string;
+      if (rushConfiguration.subspacesFeatureEnabled) {
+        // Example: C:\MyRepo\common\temp\my-subspace
+        subspaceTempFolder = path.join(commonTempFolder, RushConstants.rushTempFolderName, this.subspaceName);
+      } else {
+        // Example: C:\MyRepo\common\temp
+        subspaceTempFolder = commonTempFolder;
+      }
+
+      // Example: C:\MyRepo\common\temp\my-subspace\pnpm-lock.yaml
+      const tempShrinkwrapFilename: string = subspaceTempFolder + `/${rushConfiguration.shrinkwrapFilename}`;
+
+      /// From "C:\MyRepo\common\temp\pnpm-lock.yaml" --> "C:\MyRepo\common\temp\pnpm-lock-preinstall.yaml"
+      const parsedPath: path.ParsedPath = path.parse(tempShrinkwrapFilename);
+      const tempShrinkwrapPreinstallFilename: string = path.join(
+        parsedPath.dir,
+        parsedPath.name + '-preinstall' + parsedPath.ext
+      );
+
+      this._detail = {
+        subspaceConfigFolder,
+        subspaceTempFolder,
+        tempShrinkwrapFilename,
+        tempShrinkwrapPreinstallFilename
+      };
+    }
+    return this._detail;
+  }
+
+  /**
+   * Returns the full path of the folder containing this subspace's configuration files such as `pnpm-lock.yaml`.
+   *
+   * Example: `common/config/subspaces/my-subspace`
+   * @beta
+   */
+  public getSubspaceConfigFolder(): string {
+    return this._ensureDetail().subspaceConfigFolder;
+  }
+
+  /**
+   * The folder where the subspace's node_modules and other temporary files will be stored.
+   *
+   * Example: `common/temp/subspaces/my-subspace`
+   * @beta
+   */
+  public getSubspaceTempFolder(): string {
+    return this._ensureDetail().subspaceTempFolder;
+  }
+
+  /**
+   * Returns full path of the temporary shrinkwrap file for a specific subspace and returns the common workspace
+   * shrinkwrap if no subspaceName is provided.
+   * @remarks
+   * This function takes the subspace name, and returns the full path for the subspace's shrinkwrap file.
+   * This function also consults the deprecated option to allow for shrinkwraps to be stored under a package folder.
+   * This shrinkwrap file is used during "rush install", and may be rewritten by the package manager during installation
+   * This property merely reports the filename, the file itself may not actually exist.
+   * example: `C:\MyRepo\common\<subspace_name>\pnpm-lock.yaml`
+   * @beta
+   */
+  public getTempShrinkwrapFilename(): string {
+    return this._ensureDetail().tempShrinkwrapFilename;
+  }
+
+  /**
+   * The full path of a backup copy of tempShrinkwrapFilename. This backup copy is made
+   * before installation begins, and can be compared to determine how the package manager
+   * modified tempShrinkwrapFilename.
+   * @remarks
+   * This property merely reports the filename; the file itself may not actually exist.
+   * Example: `C:\MyRepo\common\temp\npm-shrinkwrap-preinstall.json`
+   * or `C:\MyRepo\common\temp\pnpm-lock-preinstall.yaml`
+   * @beta
+   */
+  public getTempShrinkwrapPreinstallFilename(subspaceName?: string | undefined): string {
+    return this._ensureDetail().tempShrinkwrapPreinstallFilename;
+  }
+
+  /**
+   * Gets the path to the common-versions.json config file for this subspace.
+   *
+   * Example: `C:\MyRepo\common\subspaces\my-subspace\common-versions.json`
+   * @beta
+   */
+  public getCommonVersionsFilePath(): string {
+    return this._ensureDetail().subspaceConfigFolder + '/' + RushConstants.commonVersionsFilename;
+  }
+
+  /**
+   * Gets the settings from the common-versions.json config file for a specific variant.
+   * @param variant - The name of the current variant in use by the active command.
+   * @beta
+   */
+  public getCommonVersions(): CommonVersionsConfiguration {
+    const commonVersionsFilename: string = this.getCommonVersionsFilePath();
+    if (!this._commonVersionsConfiguration) {
+      this._commonVersionsConfiguration = CommonVersionsConfiguration.loadFromFile(commonVersionsFilename);
+    }
+    return this._commonVersionsConfiguration;
+  }
+
+  /**
+   * Gets the path to the repo-state.json file for a specific variant.
+   * @param variant - The name of the current variant in use by the active command.
+   * @beta
+   */
+  public getRepoStateFilePath(): string {
+    return this._ensureDetail().subspaceConfigFolder + '/' + RushConstants.repoStateFilename;
+  }
+
+  /**
+   * Gets the contents from the repo-state.json file for a specific variant.
+   * @param subspaceName - The name of the subspace in use by the active command.
+   * @param variant - The name of the current variant in use by the active command.
+   * @beta
+   */
+  public getRepoState(): RepoStateFile {
+    const repoStateFilename: string = this.getRepoStateFilePath();
+    return RepoStateFile.loadFromFile(repoStateFilename);
+  }
+
+  /**
+   * Gets the committed shrinkwrap file name for a specific variant.
+   * @param variant - The name of the current variant in use by the active command.
+   * @beta
+   */
+  public getCommittedShrinkwrapFilename(): string {
+    const subspaceConfigFolderPath: string = this.getSubspaceConfigFolder();
+    return path.join(subspaceConfigFolderPath, this._rushConfiguration.shrinkwrapFilename);
+  }
+
+  /**
+   * Gets the absolute path for "pnpmfile.js" for a specific subspace.
+   * @param subspace - The name of the current subspace in use by the active command.
+   * @remarks
+   * The file path is returned even if PNPM is not configured as the package manager.
+   * @beta
+   */
+  public getPnpmfilePath(): string {
+    const subspaceConfigFolderPath: string = this.getSubspaceConfigFolder();
+
+    return path.join(
+      subspaceConfigFolderPath,
+      (this._rushConfiguration.packageManagerWrapper as PnpmPackageManager).pnpmfileFilename
+    );
+  }
+
+  /**
+   * Returns true if the specified project belongs to this subspace.
+   * @beta
+   */
+  public contains(project: RushConfigurationProject): boolean {
+    return project.subspace.subspaceName === this.subspaceName;
+  }
+
+  /** @internal */
+  public _addProject(project: RushConfigurationProject): void {
+    this._projects.push(project);
+  }
+}

--- a/libraries/rush-lib/src/api/VersionPolicyConfiguration.ts
+++ b/libraries/rush-lib/src/api/VersionPolicyConfiguration.ts
@@ -68,7 +68,7 @@ export class VersionPolicyConfiguration {
   /**
    * Validate the version policy configuration against the rush config
    */
-  public validate(projectsByName: Map<string, RushConfigurationProject>): void {
+  public validate(projectsByName: ReadonlyMap<string, RushConfigurationProject>): void {
     if (!this.versionPolicies) {
       return;
     }

--- a/libraries/rush-lib/src/api/test/RushConfiguration.test.ts
+++ b/libraries/rush-lib/src/api/test/RushConfiguration.test.ts
@@ -51,10 +51,10 @@ describe(RushConfiguration.name, () => {
     assertPathProperty('commonFolder', rushConfiguration.commonFolder, './repo/common');
     assertPathProperty(
       'commonRushConfigFolder',
-      rushConfiguration.getCommonRushConfigFolder(),
+      rushConfiguration.commonRushConfigFolder,
       './repo/common/config/rush'
     );
-    assertPathProperty('commonTempFolder', rushConfiguration.getCommonTempFolder(), './repo/common/temp');
+    assertPathProperty('commonTempFolder', rushConfiguration.commonTempFolder, './repo/common/temp');
     assertPathProperty('npmCacheFolder', rushConfiguration.npmCacheFolder, './repo/common/temp/npm-cache');
     assertPathProperty('npmTmpFolder', rushConfiguration.npmTmpFolder, './repo/common/temp/npm-tmp');
     expect(rushConfiguration.pnpmOptions.pnpmStore).toEqual('local');
@@ -124,10 +124,10 @@ describe(RushConfiguration.name, () => {
     assertPathProperty('commonFolder', rushConfiguration.commonFolder, './repo/common');
     assertPathProperty(
       'commonRushConfigFolder',
-      rushConfiguration.getCommonRushConfigFolder(),
+      rushConfiguration.commonRushConfigFolder,
       './repo/common/config/rush'
     );
-    assertPathProperty('commonTempFolder', rushConfiguration.getCommonTempFolder(), './repo/common/temp');
+    assertPathProperty('commonTempFolder', rushConfiguration.commonTempFolder, './repo/common/temp');
     assertPathProperty('npmCacheFolder', rushConfiguration.npmCacheFolder, './repo/common/temp/npm-cache');
     assertPathProperty('npmTmpFolder', rushConfiguration.npmTmpFolder, './repo/common/temp/npm-tmp');
     expect(rushConfiguration.pnpmOptions.pnpmStore).toEqual('local');
@@ -198,7 +198,7 @@ describe(RushConfiguration.name, () => {
     const rushFilename: string = path.resolve(__dirname, 'repo', 'rush-pnpm.json');
     const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
 
-    assertPathProperty('commonTempFolder', rushConfiguration.getCommonTempFolder(), expectedValue);
+    assertPathProperty('commonTempFolder', rushConfiguration.commonTempFolder, expectedValue);
     assertPathProperty(
       'npmCacheFolder',
       rushConfiguration.npmCacheFolder,

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -282,7 +282,7 @@ export class RushCommandLineParser extends CommandLineParser {
     let commandLineConfigFilePath: string | undefined;
     if (this.rushConfiguration) {
       commandLineConfigFilePath = path.join(
-        this.rushConfiguration.getCommonRushConfigFolder(),
+        this.rushConfiguration.commonRushConfigFolder,
         RushConstants.commandLineFilename
       );
     }

--- a/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
@@ -102,7 +102,7 @@ export class RushPnpmCommandLineParser {
       );
     }
 
-    const workspaceFolder: string = rushConfiguration.getCommonTempFolder();
+    const workspaceFolder: string = rushConfiguration.commonTempFolder;
     const workspaceFilePath: string = path.join(workspaceFolder, 'pnpm-workspace.yaml');
 
     if (!FileSystem.exists(workspaceFilePath)) {
@@ -292,7 +292,7 @@ export class RushPnpmCommandLineParser {
         }
         case 'patch-commit': {
           const pnpmOptionsJsonFilename: string = path.join(
-            this._rushConfiguration.getCommonRushConfigFolder(),
+            this._rushConfiguration.commonRushConfigFolder,
             RushConstants.pnpmConfigFilename
           );
           if (this._rushConfiguration.rushConfigurationJson.pnpmOptions) {
@@ -347,7 +347,7 @@ export class RushPnpmCommandLineParser {
 
   private _execute(): void {
     const rushConfiguration: RushConfiguration = this._rushConfiguration;
-    const workspaceFolder: string = rushConfiguration.getCommonTempFolder();
+    const workspaceFolder: string = rushConfiguration.commonTempFolder;
     const pnpmEnvironmentMap: EnvironmentMap = new EnvironmentMap(process.env);
     pnpmEnvironmentMap.set('NPM_CONFIG_WORKSPACE_DIR', workspaceFolder);
 
@@ -397,9 +397,7 @@ export class RushPnpmCommandLineParser {
     switch (commandName) {
       case 'patch-commit': {
         // Example: "C:\MyRepo\common\temp\package.json"
-        const commonPackageJsonFilename: string = `${this._rushConfiguration.getCommonTempFolder()}/${
-          FileConstants.PackageJson
-        }`;
+        const commonPackageJsonFilename: string = `${this._rushConfiguration.commonTempFolder}/${FileConstants.PackageJson}`;
         const commonPackageJson: JsonObject = JsonFile.load(commonPackageJsonFilename);
         const newGlobalPatchedDependencies: Record<string, string> | undefined =
           commonPackageJson?.pnpm?.patchedDependencies;
@@ -407,9 +405,7 @@ export class RushPnpmCommandLineParser {
           this._rushConfiguration.pnpmOptions.globalPatchedDependencies;
 
         if (!objectsAreDeepEqual(currentGlobalPatchedDependencies, newGlobalPatchedDependencies)) {
-          const commonTempPnpmPatchesFolder: string = `${this._rushConfiguration.getCommonTempFolder()}/${
-            RushConstants.pnpmPatchesFolderName
-          }`;
+          const commonTempPnpmPatchesFolder: string = `${this._rushConfiguration.commonTempFolder}/${RushConstants.pnpmPatchesFolderName}`;
           const rushPnpmPatchesFolder: string = `${this._rushConfiguration.commonFolder}/pnpm-${RushConstants.pnpmPatchesFolderName}`;
           // Copy (or delete) common\temp\patches\ --> common\pnpm-patches\
           if (FileSystem.exists(commonTempPnpmPatchesFolder)) {
@@ -447,7 +443,7 @@ export class RushPnpmCommandLineParser {
   }
 
   private async _doRushUpdateAsync(): Promise<void> {
-    if (this._rushConfiguration.subspacesConfiguration?.enabled) {
+    if (this._rushConfiguration.subspacesFeatureEnabled) {
       this._terminal.writeLine(Colors.red('Rush Pnpm is currently unsupported with subspaces.'));
       throw new AlreadyReportedError();
     }
@@ -471,7 +467,9 @@ export class RushPnpmCommandLineParser {
       variant: undefined,
       maxInstallAttempts: RushConstants.defaultMaxInstallAttempts,
       pnpmFilterArguments: [],
-      checkOnly: false
+      checkOnly: false,
+      // TODO: Support subspaces
+      selectedSubspace: undefined
     };
 
     const installManagerFactoryModule: typeof import('../logic/InstallManagerFactory') = await import(

--- a/libraries/rush-lib/src/cli/RushXCommandLine.ts
+++ b/libraries/rush-lib/src/cli/RushXCommandLine.ts
@@ -200,7 +200,7 @@ export class RushXCommandLine {
       workingDirectory: packageFolder,
       // If there is a rush.json then use its .npmrc from the temp folder.
       // Otherwise look for npmrc in the project folder.
-      initCwd: rushConfiguration ? rushConfiguration.getCommonTempFolder() : packageFolder,
+      initCwd: rushConfiguration ? rushConfiguration.commonTempFolder : packageFolder,
       handleOutput: false,
       environmentPathOptions: {
         includeProjectBin: true

--- a/libraries/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -64,7 +64,7 @@ export abstract class BaseConfiglessRushAction extends CommandLineAction impleme
 
     if (this.rushConfiguration) {
       if (!this._safeForSimultaneousRushProcesses) {
-        if (!LockFile.tryAcquire(this.rushConfiguration.getCommonTempFolder(), 'rush')) {
+        if (!LockFile.tryAcquire(this.rushConfiguration.commonTempFolder, 'rush')) {
           // eslint-disable-next-line no-console
           console.log(colors.red(`Another Rush command is already running in this repository.`));
           process.exit(1);
@@ -90,7 +90,7 @@ export abstract class BaseConfiglessRushAction extends CommandLineAction impleme
       // eslint-disable-next-line dot-notation
       let environmentPath: string | undefined = process.env['PATH'];
       environmentPath =
-        path.join(this.rushConfiguration.getCommonTempFolder(), 'node_modules', '.bin') +
+        path.join(this.rushConfiguration.commonTempFolder, 'node_modules', '.bin') +
         path.delimiter +
         environmentPath;
       // eslint-disable-next-line dot-notation

--- a/libraries/rush-lib/src/cli/actions/DeployAction.ts
+++ b/libraries/rush-lib/src/cli/actions/DeployAction.ts
@@ -147,11 +147,11 @@ export class DeployAction extends BaseRushAction {
     if (this.rushConfiguration.packageManager === 'pnpm') {
       const pnpmfileConfiguration: PnpmfileConfiguration = await PnpmfileConfiguration.initializeAsync(
         this.rushConfiguration,
-        undefined
+        this.rushConfiguration.defaultSubspace
       );
       transformPackageJson = pnpmfileConfiguration.transform.bind(pnpmfileConfiguration);
       if (!scenarioConfiguration.json.omitPnpmWorkaroundLinks) {
-        pnpmInstallFolder = this.rushConfiguration.getCommonTempFolder();
+        pnpmInstallFolder = this.rushConfiguration.commonTempFolder;
       }
     }
 

--- a/libraries/rush-lib/src/cli/actions/InstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/InstallAction.ts
@@ -8,6 +8,7 @@ import { BaseInstallAction } from './BaseInstallAction';
 import type { IInstallManagerOptions } from '../../logic/base/BaseInstallManagerTypes';
 import type { RushCommandLineParser } from '../RushCommandLineParser';
 import { SelectionParameterSet } from '../parsing/SelectionParameterSet';
+import type { Subspace } from '../../api/Subspace';
 
 export class InstallAction extends BaseInstallAction {
   private readonly _checkOnlyParameter: CommandLineFlagParameter;
@@ -46,6 +47,9 @@ export class InstallAction extends BaseInstallAction {
 
   protected async buildInstallOptionsAsync(): Promise<IInstallManagerOptions> {
     const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
+    const selectedSubspace: Subspace | undefined = this._subspaceParameter.value
+      ? this.rushConfiguration.getSubspace(this._subspaceParameter.value)
+      : undefined;
     return {
       debug: this.parser.isDebug,
       allowShrinkwrapUpdates: false,
@@ -64,8 +68,7 @@ export class InstallAction extends BaseInstallAction {
       // These are derived independently of the selection for command line brevity
       pnpmFilterArguments: await this._selectionParameters!.getPnpmFilterArgumentsAsync(terminal),
       checkOnly: this._checkOnlyParameter.value,
-      subspaceName: this._subspaceParameter.value,
-
+      selectedSubspace,
       beforeInstallAsync: () => this.rushSession.hooks.beforeInstall.promise(this)
     };
   }

--- a/libraries/rush-lib/src/cli/actions/PublishAction.ts
+++ b/libraries/rush-lib/src/cli/actions/PublishAction.ts
@@ -212,15 +212,19 @@ export class PublishAction extends BaseRushAction {
    * Executes the publish action, which will read change request files, apply changes to package.jsons,
    */
   protected async runAsync(): Promise<void> {
-    await PolicyValidator.validatePolicyAsync(this.rushConfiguration, { bypassPolicy: false });
+    await PolicyValidator.validatePolicyAsync(
+      this.rushConfiguration,
+      this.rushConfiguration.defaultSubspace,
+      { bypassPolicy: false }
+    );
 
     // Example: "common\temp\publish-home"
-    this._targetNpmrcPublishFolder = path.join(this.rushConfiguration.getCommonTempFolder(), 'publish-home');
+    this._targetNpmrcPublishFolder = path.join(this.rushConfiguration.commonTempFolder, 'publish-home');
 
     // Example: "common\temp\publish-home\.npmrc"
     this._targetNpmrcPublishPath = path.join(this._targetNpmrcPublishFolder, '.npmrc');
 
-    const allPackages: Map<string, RushConfigurationProject> = this.rushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> = this.rushConfiguration.projectsByName;
 
     if (this._regenerateChangelogs.value) {
       // eslint-disable-next-line no-console
@@ -268,7 +272,7 @@ export class PublishAction extends BaseRushAction {
   private async _publishChangesAsync(
     git: Git,
     publishGit: PublishGit,
-    allPackages: Map<string, RushConfigurationProject>
+    allPackages: ReadonlyMap<string, RushConfigurationProject>
   ): Promise<void> {
     const changeManager: ChangeManager = new ChangeManager(this.rushConfiguration);
     await changeManager.loadAsync(
@@ -348,7 +352,7 @@ export class PublishAction extends BaseRushAction {
     }
   }
 
-  private _publishAll(git: PublishGit, allPackages: Map<string, RushConfigurationProject>): void {
+  private _publishAll(git: PublishGit, allPackages: ReadonlyMap<string, RushConfigurationProject>): void {
     // eslint-disable-next-line no-console
     console.log(`Rush publish starts with includeAll and version policy ${this._versionPolicy.value}`);
 
@@ -524,7 +528,7 @@ export class PublishAction extends BaseRushAction {
       const tarballPath: string = path.join(project.publishFolder, tarballName);
       const destFolder: string = this._releaseFolder.value
         ? this._releaseFolder.value
-        : path.join(this.rushConfiguration.getCommonTempFolder(), 'artifacts', 'packages');
+        : path.join(this.rushConfiguration.commonTempFolder, 'artifacts', 'packages');
 
       FileSystem.move({
         sourcePath: tarballPath,
@@ -576,11 +580,7 @@ export class PublishAction extends BaseRushAction {
     Utilities.createFolderWithRetry(this._targetNpmrcPublishFolder);
 
     // Copy down the committed "common\config\rush\.npmrc-publish" file, if there is one
-    Utilities.syncNpmrc(
-      this.rushConfiguration.getCommonRushConfigFolder(),
-      this._targetNpmrcPublishFolder,
-      true
-    );
+    Utilities.syncNpmrc(this.rushConfiguration.commonRushConfigFolder, this._targetNpmrcPublishFolder, true);
   }
 
   private _addSharedNpmConfig(env: { [key: string]: string | undefined }, args: string[]): void {

--- a/libraries/rush-lib/src/cli/actions/VersionAction.ts
+++ b/libraries/rush-lib/src/cli/actions/VersionAction.ts
@@ -95,10 +95,14 @@ export class VersionAction extends BaseRushAction {
   }
 
   protected async runAsync(): Promise<void> {
-    await PolicyValidator.validatePolicyAsync(this.rushConfiguration, {
-      bypassPolicyAllowed: true,
-      bypassPolicy: this._bypassPolicy.value
-    });
+    await PolicyValidator.validatePolicyAsync(
+      this.rushConfiguration,
+      this.rushConfiguration.defaultSubspace,
+      {
+        bypassPolicyAllowed: true,
+        bypassPolicy: this._bypassPolicy.value
+      }
+    );
     const git: Git = new Git(this.rushConfiguration);
     const userEmail: string = git.getGitEmail();
 

--- a/libraries/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
@@ -159,7 +159,7 @@ export class GlobalScriptAction extends BaseScriptAction<IGlobalCommandConfig> {
     const exitCode: number = Utilities.executeLifecycleCommand(shellCommand, {
       rushConfiguration: this.rushConfiguration,
       workingDirectory: this.rushConfiguration.rushJsonFolder,
-      initCwd: this.rushConfiguration.getCommonTempFolder(),
+      initCwd: this.rushConfiguration.commonTempFolder,
       handleOutput: false,
       environmentPathOptions: {
         includeRepoBin: true,

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -263,9 +263,11 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
     if (!this._runsBeforeInstall) {
       // TODO: Replace with last-install.flag when "rush link" and "rush unlink" are removed
-      const lastLinkFlag: LastLinkFlag = LastLinkFlagFactory.getCommonTempFlag(this.rushConfiguration);
+      const lastLinkFlag: LastLinkFlag = LastLinkFlagFactory.getCommonTempFlag(
+        this.rushConfiguration.defaultSubspace
+      );
       // Only check for a valid link flag when subspaces is not enabled
-      if (!lastLinkFlag.isValid() && !this.rushConfiguration.subspacesConfiguration?.enabled) {
+      if (!lastLinkFlag.isValid() && !this.rushConfiguration.subspacesFeatureEnabled) {
         const useWorkspaces: boolean =
           this.rushConfiguration.pnpmOptions && this.rushConfiguration.pnpmOptions.useWorkspaces;
         if (useWorkspaces) {

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
@@ -103,7 +103,8 @@ async function getCommandLineParserInstanceAsync(
 
   // Bulk tasks are hard-coded to expect install to have been completed. So, ensure the last-link.flag
   // file exists and is valid
-  LastLinkFlagFactory.getCommonTempFlag(parser.rushConfiguration).create();
+  // TODO: Support subspaces
+  LastLinkFlagFactory.getCommonTempFlag(parser.rushConfiguration.defaultSubspace).create();
 
   // Mock the command
   process.argv = ['pretend-this-is-node.exe', 'pretend-this-is-rush', taskName];
@@ -378,7 +379,7 @@ describe('RushCommandLineParser', () => {
       it('creates a custom telemetry file', async () => {
         const repoName: string = 'tapFlushTelemetryAndRunBuildActionRepo';
         const instance: IParserTestInstance = await getCommandLineParserInstanceAsync(repoName, 'build');
-        const telemetryFilePath: string = `${instance.parser.rushConfiguration.getCommonTempFolder()}/test-telemetry.json`;
+        const telemetryFilePath: string = `${instance.parser.rushConfiguration.commonTempFolder}/test-telemetry.json`;
         FileSystem.deleteFile(telemetryFilePath);
 
         /**

--- a/libraries/rush-lib/src/cli/test/RushXCommandLine.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushXCommandLine.test.ts
@@ -60,9 +60,9 @@ describe(RushXCommandLine.name, () => {
       } as RushConfigurationProject
     ];
     rushConfiguration = {
-      getCommonRushConfigFolder: () => '',
+      commonRushConfigFolder: '',
       rushJsonFolder: '',
-      getCommonTempFolder: () => 'common/temp',
+      commonTempFolder: 'common/temp',
       projects,
       tryGetProjectForPath(path: string): RushConfigurationProject | undefined {
         return projects.find((project) => project.projectFolder === path);

--- a/libraries/rush-lib/src/cli/test/rush-mock-flush-telemetry-plugin/index.ts
+++ b/libraries/rush-lib/src/cli/test/rush-mock-flush-telemetry-plugin/index.ts
@@ -10,7 +10,7 @@ import type { RushSession, RushConfiguration, ITelemetryData } from '../../../in
 export default class RushMockFlushTelemetryPlugin {
   public apply(rushSession: RushSession, rushConfiguration: RushConfiguration): void {
     async function flushTelemetry(data: ReadonlyArray<ITelemetryData>): Promise<void> {
-      const targetPath: string = `${rushConfiguration.getCommonTempFolder()}/test-telemetry.json`;
+      const targetPath: string = `${rushConfiguration.commonTempFolder}/test-telemetry.json`;
       await JsonFile.saveAsync(data, targetPath, { ignoreUndefinedValues: true });
     }
 

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -10,6 +10,7 @@ export { ApprovedPackagesPolicy } from './api/ApprovedPackagesPolicy';
 
 export { RushConfiguration, ITryFindRushJsonLocationOptions } from './api/RushConfiguration';
 
+export { Subspace } from './api/Subspace';
 export { SubspacesConfiguration } from './api/SubspacesConfiguration';
 
 export {

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -83,7 +83,6 @@ export class Autoinstaller {
       this._rushConfiguration,
       this._rushGlobalFolder,
       RushConstants.defaultMaxInstallAttempts,
-      undefined,
       this._restrictConsoleOutput
     );
 
@@ -128,7 +127,7 @@ export class Autoinstaller {
         }
 
         // Copy: .../common/autoinstallers/my-task/.npmrc
-        Utilities.syncNpmrc(this._rushConfiguration.getCommonRushConfigFolder(), autoinstallerFullPath);
+        Utilities.syncNpmrc(this._rushConfiguration.commonRushConfigFolder, autoinstallerFullPath);
 
         this._logIfConsoleOutputIsNotRestricted(
           `Installing dependencies under ${autoinstallerFullPath}...\n`
@@ -164,7 +163,6 @@ export class Autoinstaller {
       this._rushConfiguration,
       this._rushGlobalFolder,
       RushConstants.defaultMaxInstallAttempts,
-      undefined,
       this._restrictConsoleOutput
     );
 
@@ -211,7 +209,7 @@ export class Autoinstaller {
 
     this._logIfConsoleOutputIsNotRestricted();
 
-    Utilities.syncNpmrc(this._rushConfiguration.getCommonRushConfigFolder(), this.folderFullPath);
+    Utilities.syncNpmrc(this._rushConfiguration.commonRushConfigFolder, this.folderFullPath);
 
     Utilities.executeCommand({
       command: this._rushConfiguration.packageManagerToolFilename,

--- a/libraries/rush-lib/src/logic/ChangeManager.ts
+++ b/libraries/rush-lib/src/logic/ChangeManager.ts
@@ -20,7 +20,7 @@ import { ChangelogGenerator } from './ChangelogGenerator';
 export class ChangeManager {
   private _prereleaseToken!: PrereleaseToken;
   private _orderedChanges!: IChangeInfo[];
-  private _allPackages!: Map<string, RushConfigurationProject>;
+  private _allPackages!: ReadonlyMap<string, RushConfigurationProject>;
   private _allChanges!: IChangeRequests;
   private _changeFiles!: ChangeFiles;
   private _rushConfiguration: RushConfiguration;
@@ -69,7 +69,7 @@ export class ChangeManager {
     return this._orderedChanges;
   }
 
-  public get allPackages(): Map<string, RushConfigurationProject> {
+  public get allPackages(): ReadonlyMap<string, RushConfigurationProject> {
     return this._allPackages;
   }
 

--- a/libraries/rush-lib/src/logic/ChangelogGenerator.ts
+++ b/libraries/rush-lib/src/logic/ChangelogGenerator.ts
@@ -33,7 +33,7 @@ export class ChangelogGenerator {
    */
   public static updateChangelogs(
     allChanges: IChangeRequests,
-    allProjects: Map<string, RushConfigurationProject>,
+    allProjects: ReadonlyMap<string, RushConfigurationProject>,
     rushConfiguration: RushConfiguration,
     shouldCommit: boolean
   ): IChangelog[] {
@@ -64,7 +64,7 @@ export class ChangelogGenerator {
    * Fully regenerate the markdown files based on the current json files.
    */
   public static regenerateChangelogs(
-    allProjects: Map<string, RushConfigurationProject>,
+    allProjects: ReadonlyMap<string, RushConfigurationProject>,
     rushConfiguration: RushConfiguration
   ): void {
     allProjects.forEach((project) => {

--- a/libraries/rush-lib/src/logic/EventHooksManager.ts
+++ b/libraries/rush-lib/src/logic/EventHooksManager.ts
@@ -18,7 +18,7 @@ export class EventHooksManager {
   public constructor(rushConfiguration: RushConfiguration) {
     this._rushConfiguration = rushConfiguration;
     this._eventHooks = rushConfiguration.eventHooks;
-    this._commonTempFolder = rushConfiguration.getCommonTempFolder();
+    this._commonTempFolder = rushConfiguration.commonTempFolder;
   }
 
   public handle(event: Event, isDebug: boolean, ignoreHooks: boolean): void {

--- a/libraries/rush-lib/src/logic/ProjectWatcher.ts
+++ b/libraries/rush-lib/src/logic/ProjectWatcher.ts
@@ -120,7 +120,7 @@ export class ProjectWatcher {
       pathsToWatch.set(repoRoot, { recurse: false });
 
       // Watch the rush config folder non-recursively
-      pathsToWatch.set(Path.convertToSlashes(this._rushConfiguration.getCommonRushConfigFolder()), {
+      pathsToWatch.set(Path.convertToSlashes(this._rushConfiguration.commonTempFolder), {
         recurse: false
       });
 

--- a/libraries/rush-lib/src/logic/PublishUtilities.ts
+++ b/libraries/rush-lib/src/logic/PublishUtilities.ts
@@ -37,7 +37,7 @@ interface IAddChangeOptions {
   change: IChangeInfo;
   changeFilePath?: string;
   allChanges: IChangeRequests;
-  allPackages: Map<string, RushConfigurationProject>;
+  allPackages: ReadonlyMap<string, RushConfigurationProject>;
   rushConfiguration: RushConfiguration;
   prereleaseToken?: PrereleaseToken;
   projectsToExclude?: Set<string>;
@@ -50,7 +50,7 @@ export class PublishUtilities {
    * @returns Dictionary of all change requests, keyed by package name.
    */
   public static async findChangeRequestsAsync(
-    allPackages: Map<string, RushConfigurationProject>,
+    allPackages: ReadonlyMap<string, RushConfigurationProject>,
     rushConfiguration: RushConfiguration,
     changeFiles: ChangeFiles,
     includeCommitDetails?: boolean,
@@ -196,7 +196,7 @@ export class PublishUtilities {
    */
   public static updatePackages(
     allChanges: IChangeRequests,
-    allPackages: Map<string, RushConfigurationProject>,
+    allPackages: ReadonlyMap<string, RushConfigurationProject>,
     rushConfiguration: RushConfiguration,
     shouldCommit: boolean,
     prereleaseToken?: PrereleaseToken,
@@ -378,7 +378,7 @@ export class PublishUtilities {
   private static _writePackageChanges(
     change: IChangeInfo,
     allChanges: IChangeRequests,
-    allPackages: Map<string, RushConfigurationProject>,
+    allPackages: ReadonlyMap<string, RushConfigurationProject>,
     rushConfiguration: RushConfiguration,
     shouldCommit: boolean,
     prereleaseToken?: PrereleaseToken,
@@ -456,7 +456,7 @@ export class PublishUtilities {
   }
 
   private static _isCyclicDependency(
-    allPackages: Map<string, RushConfigurationProject>,
+    allPackages: ReadonlyMap<string, RushConfigurationProject>,
     packageName: string,
     dependencyName: string
   ): boolean {
@@ -468,7 +468,7 @@ export class PublishUtilities {
     packageName: string,
     dependencies: { [key: string]: string } | undefined,
     allChanges: IChangeRequests,
-    allPackages: Map<string, RushConfigurationProject>,
+    allPackages: ReadonlyMap<string, RushConfigurationProject>,
     rushConfiguration: RushConfiguration,
     prereleaseToken: PrereleaseToken | undefined,
     projectsToExclude?: Set<string>
@@ -700,7 +700,7 @@ export class PublishUtilities {
   private static _updateDownstreamDependencies(
     change: IChangeInfo,
     allChanges: IChangeRequests,
-    allPackages: Map<string, RushConfigurationProject>,
+    allPackages: ReadonlyMap<string, RushConfigurationProject>,
     rushConfiguration: RushConfiguration,
     prereleaseToken: PrereleaseToken | undefined,
     projectsToExclude?: Set<string>
@@ -750,7 +750,7 @@ export class PublishUtilities {
     dependencies: { [packageName: string]: string } | undefined,
     change: IChangeInfo,
     allChanges: IChangeRequests,
-    allPackages: Map<string, RushConfigurationProject>,
+    allPackages: ReadonlyMap<string, RushConfigurationProject>,
     rushConfiguration: RushConfiguration,
     prereleaseToken: PrereleaseToken | undefined,
     projectsToExclude?: Set<string>
@@ -831,7 +831,7 @@ export class PublishUtilities {
     dependencyName: string,
     dependencyChange: IChangeInfo,
     allChanges: IChangeRequests,
-    allPackages: Map<string, RushConfigurationProject>,
+    allPackages: ReadonlyMap<string, RushConfigurationProject>,
     rushConfiguration: RushConfiguration
   ): void {
     let currentDependencyVersion: string | undefined = dependencies[dependencyName];

--- a/libraries/rush-lib/src/logic/PurgeManager.ts
+++ b/libraries/rush-lib/src/logic/PurgeManager.ts
@@ -24,7 +24,7 @@ export class PurgeManager {
     this._rushGlobalFolder = rushGlobalFolder;
 
     const commonAsyncRecyclerPath: string = path.join(
-      this._rushConfiguration.getCommonTempFolder(),
+      this._rushConfiguration.commonTempFolder,
       RushConstants.rushRecyclerFolderName
     );
     this.commonTempFolderRecycler = new AsyncRecycler(commonAsyncRecyclerPath);
@@ -53,11 +53,11 @@ export class PurgeManager {
   public purgeNormal(): void {
     // Delete everything under common\temp except for the recycler folder itself
     // eslint-disable-next-line no-console
-    console.log('Purging ' + this._rushConfiguration.getCommonTempFolder());
+    console.log('Purging ' + this._rushConfiguration.commonTempFolder);
 
     this.commonTempFolderRecycler.moveAllItemsInFolder(
-      this._rushConfiguration.getCommonTempFolder(),
-      this._getMembersToExclude(this._rushConfiguration.getCommonTempFolder(), true)
+      this._rushConfiguration.commonTempFolder,
+      this._getMembersToExclude(this._rushConfiguration.commonTempFolder, true)
     );
   }
 

--- a/libraries/rush-lib/src/logic/SetupChecks.ts
+++ b/libraries/rush-lib/src/logic/SetupChecks.ts
@@ -67,9 +67,7 @@ export class SetupChecks {
     const seenFolders: Set<string> = new Set<string>();
 
     // Check from the real parent of the common/temp folder
-    const commonTempParent: string = path.dirname(
-      FileSystem.getRealPath(rushConfiguration.getCommonTempFolder())
-    );
+    const commonTempParent: string = path.dirname(FileSystem.getRealPath(rushConfiguration.commonTempFolder));
     SetupChecks._collectPhantomFoldersUpwards(commonTempParent, phantomFolders, seenFolders);
 
     // Check from the real folder containing rush.json

--- a/libraries/rush-lib/src/logic/Telemetry.ts
+++ b/libraries/rush-lib/src/logic/Telemetry.ts
@@ -143,7 +143,7 @@ export class Telemetry {
     this._store = [];
 
     const folderName: string = 'telemetry';
-    this._dataFolder = path.join(this._rushConfiguration.getCommonTempFolder(), folderName);
+    this._dataFolder = path.join(this._rushConfiguration.commonTempFolder, folderName);
   }
 
   public log(telemetryData: ITelemetryData): void {

--- a/libraries/rush-lib/src/logic/TempProjectHelper.ts
+++ b/libraries/rush-lib/src/logic/TempProjectHelper.ts
@@ -8,29 +8,27 @@ import * as path from 'path';
 import type { RushConfigurationProject } from '../api/RushConfigurationProject';
 import type { RushConfiguration } from '../api/RushConfiguration';
 import { RushConstants } from './RushConstants';
+import type { Subspace } from '../api/Subspace';
 
 // The PosixModeBits are intended to be used with bitwise operations.
 /* eslint-disable no-bitwise */
 
 export class TempProjectHelper {
   private _rushConfiguration: RushConfiguration;
+  private _subspace: Subspace;
 
-  public constructor(rushConfiguration: RushConfiguration) {
+  public constructor(rushConfiguration: RushConfiguration, subspace: Subspace) {
     this._rushConfiguration = rushConfiguration;
+    this._subspace = subspace;
   }
 
   /**
    * Deletes the existing tarball and creates a tarball for the given rush project
    */
-  public createTempProjectTarball(
-    rushProject: RushConfigurationProject,
-    subspaceName: string | undefined
-  ): void {
-    FileSystem.ensureFolder(
-      path.resolve(this._rushConfiguration.getCommonTempFolder(subspaceName), 'projects')
-    );
-    const tarballFile: string = this.getTarballFilePath(rushProject, subspaceName);
-    const tempProjectFolder: string = this.getTempProjectFolder(rushProject, subspaceName);
+  public createTempProjectTarball(rushProject: RushConfigurationProject): void {
+    FileSystem.ensureFolder(path.resolve(this._subspace.getSubspaceTempFolder(), 'projects'));
+    const tarballFile: string = this.getTarballFilePath(rushProject);
+    const tempProjectFolder: string = this.getTempProjectFolder(rushProject);
 
     FileSystem.deleteFile(tarballFile);
 
@@ -64,21 +62,18 @@ export class TempProjectHelper {
    * Gets the path to the tarball
    * Example: "C:\MyRepo\common\temp\projects\my-project-2.tgz"
    */
-  public getTarballFilePath(project: RushConfigurationProject, subspaceName: string | undefined): string {
+  public getTarballFilePath(project: RushConfigurationProject): string {
     return path.join(
-      this._rushConfiguration.getCommonTempFolder(subspaceName),
+      this._subspace.getSubspaceTempFolder(),
       RushConstants.rushTempProjectsFolderName,
       `${project.unscopedTempProjectName}.tgz`
     );
   }
 
-  public getTempProjectFolder(
-    rushProject: RushConfigurationProject,
-    subspaceName: string | undefined
-  ): string {
+  public getTempProjectFolder(rushProject: RushConfigurationProject): string {
     const unscopedTempProjectName: string = rushProject.unscopedTempProjectName;
     return path.join(
-      this._rushConfiguration.getCommonTempFolder(subspaceName),
+      this._subspace.getSubspaceTempFolder(),
       RushConstants.rushTempProjectsFolderName,
       unscopedTempProjectName
     );

--- a/libraries/rush-lib/src/logic/UnlinkManager.ts
+++ b/libraries/rush-lib/src/logic/UnlinkManager.ts
@@ -40,7 +40,7 @@ export class UnlinkManager {
       throw new AlreadyReportedError();
     }
 
-    LastLinkFlagFactory.getCommonTempFlag(this._rushConfiguration).clear();
+    LastLinkFlagFactory.getCommonTempFlag(this._rushConfiguration.defaultSubspace).clear();
     return this._deleteProjectFiles();
   }
 

--- a/libraries/rush-lib/src/logic/base/BaseInstallManagerTypes.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManagerTypes.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import type { Subspace } from '../../api/Subspace';
+
 export interface IInstallManagerOptions {
   /**
    * Whether the global "--debug" flag was specified.
@@ -94,7 +96,8 @@ export interface IInstallManagerOptions {
   beforeInstallAsync?: () => Promise<void>;
 
   /**
-   * The subspace to install for
+   * The specific subspace to install.  If `undefined`, then the `--subspace parameter was not supplied
+   * on the command line.
    */
-  subspaceName?: string;
+  selectedSubspace: Subspace | undefined;
 }

--- a/libraries/rush-lib/src/logic/base/BaseLinkManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseLinkManager.ts
@@ -189,15 +189,15 @@ export abstract class BaseLinkManager {
    * @param force - Normally the operation will be skipped if the links are already up to date;
    *   if true, this option forces the links to be recreated.
    */
-  public async createSymlinksForProjects(force: boolean, subspaceName?: string | undefined): Promise<void> {
+  public async createSymlinksForProjects(force: boolean): Promise<void> {
     // eslint-disable-next-line no-console
     console.log('\n' + colors.bold('Linking local projects'));
     const stopwatch: Stopwatch = Stopwatch.start();
 
-    await this._linkProjects(subspaceName);
+    await this._linkProjects();
 
     // TODO: Remove when "rush link" and "rush unlink" are deprecated
-    LastLinkFlagFactory.getCommonTempFlag(this._rushConfiguration).create();
+    LastLinkFlagFactory.getCommonTempFlag(this._rushConfiguration.defaultSubspace).create();
 
     stopwatch.stop();
     // eslint-disable-next-line no-console
@@ -206,5 +206,5 @@ export abstract class BaseLinkManager {
     console.log('\nNext you should probably run "rush build" or "rush rebuild"');
   }
 
-  protected abstract _linkProjects(subspaceName: string | undefined): Promise<void>;
+  protected abstract _linkProjects(): Promise<void>;
 }

--- a/libraries/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/base/BaseShrinkwrapFile.ts
@@ -13,6 +13,7 @@ import type { IExperimentsJson } from '../../api/ExperimentsConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import type { BaseProjectShrinkwrapFile } from './BaseProjectShrinkwrapFile';
 import type { PackageManagerOptionsConfigurationBase } from './BasePackageManagerOptionsConfiguration';
+import type { Subspace } from '../../api/Subspace';
 
 /**
  * This class is a parser for both npm's npm-shrinkwrap.json and pnpm's pnpm-lock.yaml file formats.
@@ -115,7 +116,7 @@ export abstract class BaseShrinkwrapFile {
    */
   public findOrphanedProjects(
     rushConfiguration: RushConfiguration,
-    subspaceName: string | undefined
+    subspace: Subspace
   ): ReadonlyArray<string> {
     const orphanedProjectNames: string[] = [];
     // We can recognize temp projects because they are under the "@rush-temp" NPM scope.
@@ -148,7 +149,7 @@ export abstract class BaseShrinkwrapFile {
    */
   public abstract isWorkspaceProjectModifiedAsync(
     project: RushConfigurationProject,
-    subspaceName: string | undefined,
+    subspace: Subspace,
     variant?: string
   ): Promise<boolean>;
 

--- a/libraries/rush-lib/src/logic/buildCache/FileSystemBuildCacheProvider.ts
+++ b/libraries/rush-lib/src/logic/buildCache/FileSystemBuildCacheProvider.ts
@@ -35,7 +35,7 @@ export class FileSystemBuildCacheProvider {
   public constructor(options: IFileSystemBuildCacheProviderOptions) {
     this._cacheFolderPath =
       options.rushUserConfiguration.buildCacheFolder ||
-      path.join(options.rushConfiguration.getCommonTempFolder(), DEFAULT_BUILD_CACHE_FOLDER_NAME);
+      path.join(options.rushConfiguration.commonTempFolder, DEFAULT_BUILD_CACHE_FOLDER_NAME);
   }
 
   /**

--- a/libraries/rush-lib/src/logic/deploy/DeployScenarioConfiguration.ts
+++ b/libraries/rush-lib/src/logic/deploy/DeployScenarioConfiguration.ts
@@ -92,7 +92,7 @@ export class DeployScenarioConfiguration {
       scenarioFileName = `deploy.json`;
     }
 
-    return path.join(rushConfiguration.getCommonRushConfigFolder(), scenarioFileName);
+    return path.join(rushConfiguration.commonRushConfigFolder, scenarioFileName);
   }
 
   public static loadFromFile(

--- a/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
+++ b/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
@@ -19,6 +19,7 @@ import { Utilities } from '../../utilities/Utilities';
 import type { IConfigurationEnvironment } from '../base/BasePackageManagerOptionsConfiguration';
 import type { PnpmOptionsConfiguration } from '../pnpm/PnpmOptionsConfiguration';
 import { merge } from '../../utilities/objectUtilities';
+import type { Subspace } from '../../api/Subspace';
 
 interface ICommonPackageJson extends IPackageJson {
   pnpm?: {
@@ -34,8 +35,8 @@ interface ICommonPackageJson extends IPackageJson {
 export class InstallHelpers {
   public static generateCommonPackageJson(
     rushConfiguration: RushConfiguration,
-    dependencies: Map<string, string> = new Map<string, string>(),
-    subspaceName: string | undefined
+    subspace: Subspace,
+    dependencies: Map<string, string> = new Map<string, string>()
   ): void {
     const commonPackageJson: ICommonPackageJson = {
       dependencies: {},
@@ -87,7 +88,7 @@ export class InstallHelpers {
 
     // Example: "C:\MyRepo\common\temp\package.json"
     const commonPackageJsonFilename: string = path.join(
-      rushConfiguration.getCommonTempFolder(subspaceName),
+      subspace.getSubspaceTempFolder(),
       FileConstants.PackageJson
     );
 
@@ -129,7 +130,6 @@ export class InstallHelpers {
     rushConfiguration: RushConfiguration,
     rushGlobalFolder: RushGlobalFolder,
     maxInstallAttempts: number,
-    subspaceName?: string | undefined,
     restrictConsoleOutput?: boolean
   ): Promise<void> {
     let logIfConsoleOutputIsNotRestricted: (message?: string) => void;
@@ -187,7 +187,7 @@ export class InstallHelpers {
         // In particular, we'll assume that two different NPM registries cannot have two
         // different implementations of the same version of the same package.
         // This was needed for: https://github.com/microsoft/rushstack/issues/691
-        commonRushConfigFolder: rushConfiguration.getCommonRushConfigFolder(subspaceName)
+        commonRushConfigFolder: rushConfiguration.commonRushConfigFolder
       });
 
       logIfConsoleOutputIsNotRestricted(
@@ -202,11 +202,11 @@ export class InstallHelpers {
     packageManagerMarker.create();
 
     // Example: "C:\MyRepo\common\temp"
-    FileSystem.ensureFolder(rushConfiguration.getCommonTempFolder(subspaceName));
+    FileSystem.ensureFolder(rushConfiguration.commonTempFolder);
 
     // Example: "C:\MyRepo\common\temp\pnpm-local"
     const localPackageManagerToolFolder: string = path.join(
-      rushConfiguration.getCommonTempFolder(subspaceName),
+      rushConfiguration.commonTempFolder,
       `${packageManager}-local`
     );
 

--- a/libraries/rush-lib/src/logic/installManager/doBasicInstallAsync.ts
+++ b/libraries/rush-lib/src/logic/installManager/doBasicInstallAsync.ts
@@ -42,7 +42,8 @@ export async function doBasicInstallAsync(options: IRunInstallOptions): Promise<
       collectLogFile: false,
       pnpmFilterArguments: [],
       maxInstallAttempts: 1,
-      networkConcurrency: undefined
+      networkConcurrency: undefined,
+      selectedSubspace: undefined
     }
   );
 

--- a/libraries/rush-lib/src/logic/npm/NpmLinkManager.ts
+++ b/libraries/rush-lib/src/logic/npm/NpmLinkManager.ts
@@ -28,12 +28,12 @@ interface IQueueItem {
 }
 
 export class NpmLinkManager extends BaseLinkManager {
-  protected async _linkProjects(subspaceName: string | undefined): Promise<void> {
+  protected async _linkProjects(): Promise<void> {
     const npmPackage: readPackageTree.Node = await LegacyAdapters.convertCallbackToPromise<
       readPackageTree.Node,
       Error,
       string
-    >(readPackageTree, this._rushConfiguration.getCommonTempFolder(subspaceName));
+    >(readPackageTree, this._rushConfiguration.commonTempFolder);
 
     const commonRootPackage: NpmPackage = NpmPackage.createFromNpm(npmPackage);
 
@@ -74,14 +74,14 @@ export class NpmLinkManager extends BaseLinkManager {
 
       // Example: "C:\MyRepo\common\temp\projects\project1
       const extractedFolder: string = path.join(
-        this._rushConfiguration.getCommonTempFolder(),
+        this._rushConfiguration.commonTempFolder,
         RushConstants.rushTempProjectsFolderName,
         unscopedTempProjectName
       );
 
       // Example: "C:\MyRepo\common\temp\projects\project1.tgz"
       const tarballFile: string = path.join(
-        this._rushConfiguration.getCommonTempFolder(),
+        this._rushConfiguration.commonTempFolder,
         RushConstants.rushTempProjectsFolderName,
         unscopedTempProjectName + '.tgz'
       );
@@ -98,7 +98,7 @@ export class NpmLinkManager extends BaseLinkManager {
 
       // Example: "C:\MyRepo\common\temp\node_modules\@rush-temp\project1"
       const installFolderName: string = path.join(
-        this._rushConfiguration.getCommonTempFolder(),
+        this._rushConfiguration.commonTempFolder,
         RushConstants.nodeModulesFolderName,
         RushConstants.rushTempNpmScope,
         unscopedTempProjectName
@@ -305,7 +305,7 @@ export class NpmLinkManager extends BaseLinkManager {
     // Also symlink the ".bin" folder
     if (localProjectPackage.children.length > 0) {
       const commonBinFolder: string = path.join(
-        this._rushConfiguration.getCommonTempFolder(),
+        this._rushConfiguration.commonTempFolder,
         'node_modules',
         '.bin'
       );

--- a/libraries/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
@@ -7,6 +7,7 @@ import { BaseShrinkwrapFile } from '../base/BaseShrinkwrapFile';
 import { DependencySpecifier } from '../DependencySpecifier';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import type { BaseProjectShrinkwrapFile } from '../base/BaseProjectShrinkwrapFile';
+import type { Subspace } from '../../api/Subspace';
 
 interface INpmShrinkwrapDependencyJson {
   version: string;
@@ -133,6 +134,7 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
   /** @override */
   public async isWorkspaceProjectModifiedAsync(
     project: RushConfigurationProject,
+    subspace: Subspace,
     variant?: string
   ): Promise<boolean> {
     throw new InternalError('Not implemented');

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -144,7 +144,7 @@ export class ShellOperationRunner implements IOperationRunner {
         {
           rushConfiguration: this._rushConfiguration,
           workingDirectory: projectFolder,
-          initCwd: this._rushConfiguration.getCommonTempFolder(),
+          initCwd: this._rushConfiguration.commonTempFolder,
           handleOutput: true,
           environmentPathOptions: {
             includeProjectBin: true

--- a/libraries/rush-lib/src/logic/pnpm/PnpmProjectShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmProjectShrinkwrapFile.ts
@@ -12,6 +12,7 @@ import type {
 } from './PnpmShrinkwrapFile';
 import type { DependencySpecifier } from '../DependencySpecifier';
 import { RushConstants } from '../RushConstants';
+import type { Subspace } from '../../api/Subspace';
 
 /**
  *
@@ -72,11 +73,10 @@ export class PnpmProjectShrinkwrapFile extends BaseProjectShrinkwrapFile<PnpmShr
 
   protected generateWorkspaceProjectShrinkwrapMap(): Map<string, string> | undefined {
     // Obtain the workspace importer from the shrinkwrap, which lists resolved dependencies
-    const subspaceName: string | undefined =
-      this.project.rushConfiguration.getProjectSubspace &&
-      this.project.rushConfiguration.getProjectSubspace(this.project);
+    const subspace: Subspace = this.project.subspace;
+
     const importerKey: string = this.shrinkwrapFile.getImporterKeyByPath(
-      this.project.rushConfiguration.getCommonTempFolder(subspaceName),
+      subspace.getSubspaceTempFolder(),
       this.project.projectFolder
     );
 

--- a/libraries/rush-lib/src/logic/pnpm/test/PnpmShrinkwrapFile.test.ts
+++ b/libraries/rush-lib/src/logic/pnpm/test/PnpmShrinkwrapFile.test.ts
@@ -133,9 +133,12 @@ describe(PnpmShrinkwrapFile.name, () => {
         const pnpmShrinkwrapFile = getPnpmShrinkwrapFileFromFile(
           `${__dirname}/yamlFiles/pnpm-lock-v5/not-modified.yaml`
         );
-        await expect(pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(project, undefined)).resolves.toBe(
-          false
-        );
+        await expect(
+          pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(
+            project,
+            project.rushConfiguration.defaultSubspace
+          )
+        ).resolves.toBe(false);
       });
 
       it('can detect modified', async () => {
@@ -143,9 +146,12 @@ describe(PnpmShrinkwrapFile.name, () => {
         const pnpmShrinkwrapFile = getPnpmShrinkwrapFileFromFile(
           `${__dirname}/yamlFiles/pnpm-lock-v5/modified.yaml`
         );
-        await expect(pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(project, undefined)).resolves.toBe(
-          true
-        );
+        await expect(
+          pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(
+            project,
+            project.rushConfiguration.defaultSubspace
+          )
+        ).resolves.toBe(true);
       });
 
       it('can detect overrides', async () => {
@@ -153,9 +159,12 @@ describe(PnpmShrinkwrapFile.name, () => {
         const pnpmShrinkwrapFile = getPnpmShrinkwrapFileFromFile(
           `${__dirname}/yamlFiles/pnpm-lock-v5/overrides-not-modified.yaml`
         );
-        await expect(pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(project, undefined)).resolves.toBe(
-          false
-        );
+        await expect(
+          pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(
+            project,
+            project.rushConfiguration.defaultSubspace
+          )
+        ).resolves.toBe(false);
       });
     });
 
@@ -165,9 +174,12 @@ describe(PnpmShrinkwrapFile.name, () => {
         const pnpmShrinkwrapFile = getPnpmShrinkwrapFileFromFile(
           `${__dirname}/yamlFiles/pnpm-lock-v6/not-modified.yaml`
         );
-        await expect(pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(project, undefined)).resolves.toBe(
-          false
-        );
+        await expect(
+          pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(
+            project,
+            project.rushConfiguration.defaultSubspace
+          )
+        ).resolves.toBe(false);
       });
 
       it('can detect modified', async () => {
@@ -175,9 +187,12 @@ describe(PnpmShrinkwrapFile.name, () => {
         const pnpmShrinkwrapFile = getPnpmShrinkwrapFileFromFile(
           `${__dirname}/yamlFiles/pnpm-lock-v6/modified.yaml`
         );
-        await expect(pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(project, undefined)).resolves.toBe(
-          true
-        );
+        await expect(
+          pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(
+            project,
+            project.rushConfiguration.defaultSubspace
+          )
+        ).resolves.toBe(true);
       });
 
       it('can detect overrides', async () => {
@@ -185,9 +200,12 @@ describe(PnpmShrinkwrapFile.name, () => {
         const pnpmShrinkwrapFile = getPnpmShrinkwrapFileFromFile(
           `${__dirname}/yamlFiles/pnpm-lock-v6/overrides-not-modified.yaml`
         );
-        await expect(pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(project, undefined)).resolves.toBe(
-          false
-        );
+        await expect(
+          pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(
+            project,
+            project.rushConfiguration.defaultSubspace
+          )
+        ).resolves.toBe(false);
       });
 
       it('can handle the inconsistent version of a package declared in dependencies and devDependencies', async () => {
@@ -195,9 +213,12 @@ describe(PnpmShrinkwrapFile.name, () => {
         const pnpmShrinkwrapFile = getPnpmShrinkwrapFileFromFile(
           `${__dirname}/yamlFiles/pnpm-lock-v6/inconsistent-dep-devDep.yaml`
         );
-        await expect(pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(project, undefined)).resolves.toBe(
-          false
-        );
+        await expect(
+          pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(
+            project,
+            project.rushConfiguration.defaultSubspace
+          )
+        ).resolves.toBe(false);
       });
     });
   });

--- a/libraries/rush-lib/src/logic/policy/PolicyValidator.ts
+++ b/libraries/rush-lib/src/logic/policy/PolicyValidator.ts
@@ -5,6 +5,7 @@ import type { RushConfiguration } from '../../api/RushConfiguration';
 import * as GitEmailPolicy from './GitEmailPolicy';
 import * as ShrinkwrapFilePolicy from './ShrinkwrapFilePolicy';
 import * as EnvironmentPolicy from './EnvironmentPolicy';
+import type { Subspace } from '../../api/Subspace';
 
 export interface IPolicyValidatorOptions {
   bypassPolicyAllowed?: boolean;
@@ -15,8 +16,8 @@ export interface IPolicyValidatorOptions {
 
 export async function validatePolicyAsync(
   rushConfiguration: RushConfiguration,
-  options: IPolicyValidatorOptions,
-  subspaceName?: string | undefined
+  subspace: Subspace,
+  options: IPolicyValidatorOptions
 ): Promise<void> {
   if (!options.bypassPolicy) {
     GitEmailPolicy.validate(rushConfiguration, options);
@@ -24,7 +25,7 @@ export async function validatePolicyAsync(
     if (!options.allowShrinkwrapUpdates) {
       // Don't validate the shrinkwrap if updates are allowed, as it's likely to change
       // It also may have merge conflict markers, which PNPM can gracefully handle, but the validator cannot
-      ShrinkwrapFilePolicy.validate(rushConfiguration, options, subspaceName);
+      ShrinkwrapFilePolicy.validate(rushConfiguration, subspace, options);
     }
   }
 }

--- a/libraries/rush-lib/src/logic/policy/ShrinkwrapFilePolicy.ts
+++ b/libraries/rush-lib/src/logic/policy/ShrinkwrapFilePolicy.ts
@@ -6,6 +6,7 @@ import type { IPolicyValidatorOptions } from './PolicyValidator';
 import type { BaseShrinkwrapFile } from '../base/BaseShrinkwrapFile';
 import { ShrinkwrapFileFactory } from '../ShrinkwrapFileFactory';
 import type { RepoStateFile } from '../RepoStateFile';
+import type { Subspace } from '../../api/Subspace';
 
 export interface IShrinkwrapFilePolicyValidatorOptions extends IPolicyValidatorOptions {
   repoState: RepoStateFile;
@@ -16,15 +17,15 @@ export interface IShrinkwrapFilePolicyValidatorOptions extends IPolicyValidatorO
  */
 export function validate(
   rushConfiguration: RushConfiguration,
-  options: IPolicyValidatorOptions,
-  subspaceName?: string | undefined
+  subspace: Subspace,
+  options: IPolicyValidatorOptions
 ): void {
   // eslint-disable-next-line no-console
   console.log('Validating package manager shrinkwrap file.\n');
   const shrinkwrapFile: BaseShrinkwrapFile | undefined = ShrinkwrapFileFactory.getShrinkwrapFile(
     rushConfiguration.packageManager,
     rushConfiguration.packageManagerOptions,
-    rushConfiguration.getCommittedShrinkwrapFilename(subspaceName)
+    subspace.getCommittedShrinkwrapFilename()
   );
 
   if (!shrinkwrapFile) {
@@ -38,7 +39,7 @@ export function validate(
     rushConfiguration.packageManagerOptions,
     {
       ...options,
-      repoState: rushConfiguration.getRepoState(options.shrinkwrapVariant)
+      repoState: subspace.getRepoState()
     },
     rushConfiguration.experimentsConfiguration.configuration
   );

--- a/libraries/rush-lib/src/logic/selectors/SubspaceSelectorParser.ts
+++ b/libraries/rush-lib/src/logic/selectors/SubspaceSelectorParser.ts
@@ -3,6 +3,8 @@
 
 import type { RushConfiguration } from '../../api/RushConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
+import type { Subspace } from '../../api/Subspace';
+import { RushConstants } from '../RushConstants';
 import type { IEvaluateSelectorOptions, ISelectorParser } from './ISelectorParser';
 
 export class SubspaceSelectorParser implements ISelectorParser<RushConfigurationProject> {
@@ -15,12 +17,20 @@ export class SubspaceSelectorParser implements ISelectorParser<RushConfiguration
   public async evaluateSelectorAsync({
     unscopedSelector
   }: IEvaluateSelectorOptions): Promise<Iterable<RushConfigurationProject>> {
-    this._rushConfiguration.validateSubspaceName(unscopedSelector);
+    const subspace: Subspace = this._rushConfiguration.getSubspace(unscopedSelector);
 
-    return this._rushConfiguration.getSubspaceProjects(unscopedSelector);
+    return subspace.getProjects();
   }
 
   public getCompletions(): Iterable<string> {
-    return this._rushConfiguration.subspaceNames;
+    // Tab completion is a performance sensitive operation, so avoid loading all the projects
+    const subspaceNames: string[] = [];
+    if (this._rushConfiguration.subspacesConfiguration) {
+      subspaceNames.push(...this._rushConfiguration.subspacesConfiguration.subspaceNames);
+    }
+    if (!subspaceNames.indexOf(RushConstants.defaultSubspaceName)) {
+      subspaceNames.push(RushConstants.defaultSubspaceName);
+    }
+    return subspaceNames;
   }
 }

--- a/libraries/rush-lib/src/logic/setup/SetupPackageRegistry.ts
+++ b/libraries/rush-lib/src/logic/setup/SetupPackageRegistry.ts
@@ -74,7 +74,7 @@ export class SetupPackageRegistry {
     );
 
     this._artifactoryConfiguration = new ArtifactoryConfiguration(
-      path.join(this.rushConfiguration.getCommonRushConfigFolder(), 'artifactory.json')
+      path.join(this.rushConfiguration.commonRushConfigFolder, 'artifactory.json')
     );
 
     this._messages = {
@@ -112,8 +112,8 @@ export class SetupPackageRegistry {
 
     if (!this._options.syncNpmrcAlreadyCalled) {
       Utilities.syncNpmrc(
-        this.rushConfiguration.getCommonRushConfigFolder(),
-        this.rushConfiguration.getCommonTempFolder()
+        this.rushConfiguration.commonRushConfigFolder,
+        this.rushConfiguration.commonTempFolder
       );
     }
 
@@ -131,7 +131,7 @@ export class SetupPackageRegistry {
     this._terminal.writeLine('Testing access to private NPM registry: ' + packageRegistry.registryUrl);
 
     const result: child_process.SpawnSyncReturns<string> = Executable.spawnSync('npm', npmArgs, {
-      currentWorkingDirectory: this.rushConfiguration.getCommonTempFolder(),
+      currentWorkingDirectory: this.rushConfiguration.commonTempFolder,
       stdio: ['ignore', 'pipe', 'pipe'],
       // Wait at most 10 seconds for "npm view" to succeed
       timeoutMs: 10 * 1000

--- a/libraries/rush-lib/src/logic/test/BaseInstallManager.test.ts
+++ b/libraries/rush-lib/src/logic/test/BaseInstallManager.test.ts
@@ -10,6 +10,7 @@ import type { IInstallManagerOptions } from '../base/BaseInstallManagerTypes';
 
 import { RushConfiguration } from '../../api/RushConfiguration';
 import { RushGlobalFolder } from '../../api/RushGlobalFolder';
+import type { Subspace } from '../../api/Subspace';
 
 class FakeBaseInstallManager extends BaseInstallManager {
   public constructor(
@@ -35,8 +36,8 @@ class FakeBaseInstallManager extends BaseInstallManager {
   protected postInstallAsync(): Promise<void> {
     return Promise.resolve();
   }
-  public pushConfigurationArgs(args: string[], options: IInstallManagerOptions): void {
-    return super.pushConfigurationArgs(args, options);
+  public pushConfigurationArgs(args: string[], options: IInstallManagerOptions, subspace: Subspace): void {
+    return super.pushConfigurationArgs(args, options, subspace);
   }
 }
 
@@ -78,14 +79,14 @@ describe('BaseInstallManager Test', () => {
     jest.spyOn(ConsoleTerminalProvider.prototype, 'write').mockImplementation(mockWrite);
 
     const argsPnpmV6: string[] = [];
-    fakeBaseInstallManager6.pushConfigurationArgs(argsPnpmV6, options);
+    fakeBaseInstallManager6.pushConfigurationArgs(argsPnpmV6, options, rushConfigurationV7.defaultSubspace);
     expect(argsPnpmV6).not.toContain(pnpmIgnoreCompatibilityDbParameter);
     expect(mockWrite.mock.calls[0][0]).toContain(
       "Warning: Your rush.json specifies a pnpmVersion with a known issue that may cause unintended version selections. It's recommended to upgrade to PNPM >=6.34.0 or >=7.9.0. For details see: https://rushjs.io/link/pnpm-issue-5132"
     );
 
     const argsPnpmV7: string[] = [];
-    fakeBaseInstallManager7.pushConfigurationArgs(argsPnpmV7, options);
+    fakeBaseInstallManager7.pushConfigurationArgs(argsPnpmV7, options, rushConfigurationV7.defaultSubspace);
     expect(argsPnpmV7).not.toContain(pnpmIgnoreCompatibilityDbParameter);
     expect(mockWrite.mock.calls[0][0]).toContain(
       "Warning: Your rush.json specifies a pnpmVersion with a known issue that may cause unintended version selections. It's recommended to upgrade to PNPM >=6.34.0 or >=7.9.0. For details see: https://rushjs.io/link/pnpm-issue-5132"
@@ -109,7 +110,7 @@ describe('BaseInstallManager Test', () => {
     jest.spyOn(ConsoleTerminalProvider.prototype, 'write').mockImplementation(mockWrite);
 
     const args: string[] = [];
-    fakeBaseInstallManager.pushConfigurationArgs(args, options);
+    fakeBaseInstallManager.pushConfigurationArgs(args, options, rushConfiguration.defaultSubspace);
     expect(args).toContain(pnpmIgnoreCompatibilityDbParameter);
 
     if (mockWrite.mock.calls.length) {

--- a/libraries/rush-lib/src/logic/test/InstallHelpers.test.ts
+++ b/libraries/rush-lib/src/logic/test/InstallHelpers.test.ts
@@ -23,7 +23,11 @@ describe('InstallHelpers', () => {
       const RUSH_JSON_FILENAME: string = `${__dirname}/pnpmConfig/rush.json`;
       const rushConfiguration: RushConfiguration =
         RushConfiguration.loadFromConfigurationFile(RUSH_JSON_FILENAME);
-      InstallHelpers.generateCommonPackageJson(rushConfiguration, undefined, undefined);
+      InstallHelpers.generateCommonPackageJson(
+        rushConfiguration,
+        rushConfiguration.defaultSubspace,
+        undefined
+      );
       const packageJson: IPackageJson = mockJsonFileSave.mock.calls[0][0];
       expect(packageJson).toEqual(
         expect.objectContaining({

--- a/libraries/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
+++ b/libraries/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
@@ -26,10 +26,10 @@ describe(ProjectChangeAnalyzer.name, () => {
     files: Map<string, string>
   ): ProjectChangeAnalyzer {
     const rushConfiguration: RushConfiguration = {
-      getCommonRushConfigFolder: () => '',
+      commonRushConfigFolder: '',
       projects,
       rushJsonFolder: '',
-      getCommittedShrinkwrapFilename(subspaceName?: string | undefined): string {
+      getCommittedShrinkwrapFilename(): string {
         return 'common/config/rush/pnpm-lock.yaml';
       },
       getProjectLookupForRoot(root: string): LookupByPath<RushConfigurationProject> {

--- a/libraries/rush-lib/src/logic/test/PublishUtilities.test.ts
+++ b/libraries/rush-lib/src/logic/test/PublishUtilities.test.ts
@@ -10,7 +10,7 @@ import { ChangeFiles } from '../ChangeFiles';
 /* eslint-disable dot-notation */
 
 function generateChangeSnapshot(
-  allPackages: Map<string, RushConfigurationProject>,
+  allPackages: ReadonlyMap<string, RushConfigurationProject>,
   allChanges: IChangeRequests
 ): string {
   const unchangedLines: string[] = [];
@@ -82,7 +82,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns no changes in an empty change folder', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -94,7 +95,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns 1 change when changing a leaf package', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -109,7 +111,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns 6 changes when patching a root package', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -142,7 +145,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns 8 changes when hotfixing a root package', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -173,7 +177,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns 9 changes when major bumping a root package', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -206,7 +211,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('updates policy project dependencies when updating a lockstep version policy with no nextBump', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -239,7 +245,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns 2 changes when bumping cyclic dependencies', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -270,7 +277,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns error when mixing hotfix and non-hotfix changes', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     await expect(
       async () =>
         await PublishUtilities.findChangeRequestsAsync(
@@ -282,7 +290,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns error when adding hotfix with config disabled', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     // Overload hotfixChangeEnabled function
     (packagesRushConfiguration as unknown as Record<string, boolean>).hotfixChangeEnabled = false;
 
@@ -297,7 +306,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('can resolve multiple changes requests on the same package', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -330,7 +340,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('can resolve multiple reverse-ordered changes requests on the same package', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -363,7 +374,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('can resolve multiple hotfix changes', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -394,7 +406,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('can update an explicit dependency', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -425,7 +438,7 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('can exclude lock step projects', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = repoRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> = repoRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       repoRushConfiguration,
@@ -465,7 +478,7 @@ describe(PublishUtilities.sortChangeRequests.name, () => {
   });
 
   it('can return a sorted array of the change requests to be published in the correct order', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = rushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> = rushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       rushConfiguration,
@@ -553,7 +566,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns no changes in an empty change folder', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -565,7 +579,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns 1 change when changing a leaf package', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -580,7 +595,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns 6 changes when patching a root package', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -613,7 +629,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns 8 changes when hotfixing a root package', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -644,7 +661,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns 9 changes when major bumping a root package', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -677,7 +695,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns 2 changes when bumping cyclic dependencies', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -708,7 +727,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns error when mixing hotfix and non-hotfix changes', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     await expect(
       async () =>
         await PublishUtilities.findChangeRequestsAsync(
@@ -720,7 +740,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('returns error when adding hotfix with config disabled', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     // Overload hotfixChangeEnabled function
     (packagesRushConfiguration as unknown as Record<string, boolean>).hotfixChangeEnabled = false;
 
@@ -735,7 +756,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('can resolve multiple changes requests on the same package', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -768,7 +790,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('can resolve multiple reverse-ordered changes requests on the same package', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -801,7 +824,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('can resolve multiple hotfix changes', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -832,7 +856,8 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('can update an explicit dependency', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = packagesRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> =
+      packagesRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       packagesRushConfiguration,
@@ -850,7 +875,7 @@ describe(PublishUtilities.findChangeRequestsAsync.name, () => {
   });
 
   it('can exclude lock step projects', async () => {
-    const allPackages: Map<string, RushConfigurationProject> = repoRushConfiguration.projectsByName;
+    const allPackages: ReadonlyMap<string, RushConfigurationProject> = repoRushConfiguration.projectsByName;
     const allChanges: IChangeRequests = await PublishUtilities.findChangeRequestsAsync(
       allPackages,
       repoRushConfiguration,

--- a/libraries/rush-lib/src/logic/test/ShrinkwrapFile.test.ts
+++ b/libraries/rush-lib/src/logic/test/ShrinkwrapFile.test.ts
@@ -154,7 +154,10 @@ describe(PnpmShrinkwrapFile.name, () => {
             projectRushTempFolder: `${projectName}/.rush/temp`,
             projectFolder: projectName,
             rushConfiguration: {
-              getCommonTempFolder: () => 'common/temp'
+              commonTempFolder: 'common/temp'
+            },
+            subspace: {
+              getSubspaceTempFolder: () => 'common/temp'
             }
           } as RushConfigurationProject;
 

--- a/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
+++ b/libraries/rush-lib/src/logic/versionMismatch/VersionMismatchFinder.ts
@@ -12,12 +12,13 @@ import { VersionMismatchFinderProject } from './VersionMismatchFinderProject';
 import { VersionMismatchFinderCommonVersions } from './VersionMismatchFinderCommonVersions';
 import { CustomTipId } from '../../api/CustomTipsConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
+import type { Subspace } from '../../api/Subspace';
 
 const TRUNCATE_AFTER_PACKAGE_NAME_COUNT: number = 5;
 
 export interface IVersionMismatchFinderOptions {
   variant?: string | undefined;
-  subspaceName?: string | undefined;
+  subspace?: Subspace;
 }
 
 export interface IVersionMismatchFinderRushCheckOptions extends IVersionMismatchFinderOptions {
@@ -99,9 +100,9 @@ export class VersionMismatchFinder {
     rushConfiguration: RushConfiguration,
     options: IVersionMismatchFinderOptions = {}
   ): VersionMismatchFinder {
-    const commonVersions: CommonVersionsConfiguration = rushConfiguration.getCommonVersions(
-      options.subspaceName
-    );
+    const commonVersions: CommonVersionsConfiguration = (
+      options.subspace ?? rushConfiguration.defaultSubspace
+    ).getCommonVersions();
 
     const projects: VersionMismatchFinderEntity[] = [];
 
@@ -111,8 +112,8 @@ export class VersionMismatchFinder {
 
     // If subspace is specified, only go through projects in that subspace
     let projectsToParse: RushConfigurationProject[] = [];
-    if (options.subspaceName) {
-      projectsToParse = rushConfiguration.getSubspaceProjects(options.subspaceName);
+    if (options.subspace) {
+      projectsToParse = options.subspace.getProjects();
     } else {
       projectsToParse = rushConfiguration.projects;
     }

--- a/libraries/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/yarn/YarnShrinkwrapFile.ts
@@ -13,6 +13,7 @@ import type { DependencySpecifier } from '../DependencySpecifier';
 import { PackageNameParsers } from '../../api/PackageNameParsers';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import type { BaseProjectShrinkwrapFile } from '../base/BaseProjectShrinkwrapFile';
+import type { Subspace } from '../../api/Subspace';
 
 /**
  * @yarnpkg/lockfile doesn't have types
@@ -285,6 +286,7 @@ export class YarnShrinkwrapFile extends BaseShrinkwrapFile {
   /** @override */
   public async isWorkspaceProjectModifiedAsync(
     project: RushConfigurationProject,
+    subspace: Subspace,
     variant?: string
   ): Promise<boolean> {
     throw new InternalError('Not implemented');

--- a/libraries/rush-lib/src/utilities/Utilities.ts
+++ b/libraries/rush-lib/src/utilities/Utilities.ts
@@ -594,9 +594,7 @@ export class Utilities {
         ...options.environmentPathOptions,
         rushJsonFolder: options.rushConfiguration?.rushJsonFolder,
         projectRoot: options.workingDirectory,
-        commonTempFolder: options.rushConfiguration
-          ? options.rushConfiguration.getCommonTempFolder()
-          : undefined
+        commonTempFolder: options.rushConfiguration ? options.rushConfiguration.commonTempFolder : undefined
       }
     });
 


### PR DESCRIPTION
- Introduce a `Subspace` class
- Replace `subspaceName: string` with `subspace: Subspace`
- The `RushConfiguration.defaultSubspace` API is always defined; when the feature is turned off, this API returns a subspace object representing the classic Rush folder layout
- This simplifies the logic, because the `subspace: Subspace` parameter is generally never `undefined`, with two exceptions:
  - When the parameter indicates the presence or absence of `--subspace`, I've renamed that to `selectedSubspace`
  - When the parameter indicates the **rush.json** field, I've renamed that to `configuredSubspaceName`
- The old APIs such as `RushConfiguration.getRepoState()` are now `@deprecated` with a notice that everyone should now use `Subspace.getRepoState()` instead (even when the feature is turned off)
- `Subspace.isValidSubspaceName()` was replaced by an API for checking the syntax of names; checking whether a subspace is defined is now easily done via APIs such as `RushConfiguration.tryGetSubspace()`
- The terminology `commonRushConfigFolder` and `commonTempFolder` is never reinterpreted with subspaces; new terminology is introduced for the subspace subfolders:
  - `RushConfiguration.commonRushConfigFolder` --> **common/config/rush**
  - `RushConfiguration.commonTempFolder` --> **common/temp**
  - `Subspace.getSubspaceConfigFolder()` --> **common/config/subspaces/my-subspace**
  - `Subspace.getSubspaceTempFolder()` --> **common/temp/my-subspace**
