### PR TITLE
Rename "enabled" -> "subspacesEnabled"

### DIFF
--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -1375,13 +1375,14 @@ export class Subspace {
 export class SubspacesConfiguration {
     // @internal
     static _convertNameToEnvironmentVariable(subspaceName: string, splitWorkspaceCompatibility: boolean): string;
-    readonly enabled: boolean;
     static explainIfInvalidSubspaceName(subspaceName: string, splitWorkspaceCompatibility?: boolean): string | undefined;
     readonly preventSelectingAllSubspaces: boolean;
     static requireValidSubspaceName(subspaceName: string, splitWorkspaceCompatibility?: boolean): void;
     readonly splitWorkspaceCompatibility: boolean;
     readonly subspaceJsonFilePath: string;
     readonly subspaceNames: ReadonlySet<string>;
+    // (undocumented)
+    readonly subspacesEnabled: boolean;
     // (undocumented)
     static tryLoadFromConfigurationFile(subspaceJsonFilePath: string): SubspacesConfiguration | undefined;
     // (undocumented)

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/subspaces.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/subspaces.json
@@ -9,7 +9,7 @@
   /**
    * Set this flag to "true" to enable usage of subspaces.
    */
-  "enabled": false,
+  "subspacesEnabled": false,
 
   /**
    * (DEPRECATED) This is a temporary workaround for migrating from an earlier prototype

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -633,7 +633,7 @@ export class RushConfiguration {
 
     // Try getting a subspace configuration
     this.subspacesConfiguration = SubspacesConfiguration.tryLoadFromDefaultLocation(this);
-    this.subspacesFeatureEnabled = !!this.subspacesConfiguration?.enabled;
+    this.subspacesFeatureEnabled = !!this.subspacesConfiguration?.subspacesEnabled;
 
     this._subspacesByName = new Map();
 
@@ -860,7 +860,7 @@ export class RushConfiguration {
     // Build the subspaces map
     const subspaceNames: string[] = [];
     let splitWorkspaceCompatibility: boolean = false;
-    if (this.subspacesConfiguration?.enabled) {
+    if (this.subspacesConfiguration?.subspacesEnabled) {
       splitWorkspaceCompatibility = this.subspacesConfiguration.splitWorkspaceCompatibility;
 
       subspaceNames.push(...this.subspacesConfiguration.subspaceNames);

--- a/libraries/rush-lib/src/api/SubspacesConfiguration.ts
+++ b/libraries/rush-lib/src/api/SubspacesConfiguration.ts
@@ -21,7 +21,7 @@ export const SPLIT_WORKSPACE_SUBSPACE_NAME_REGEXP: RegExp = /^[a-z0-9][+_\-a-z0-
  * See subspace.schema.json for documentation.
  */
 interface ISubspacesConfigurationJson {
-  enabled: boolean;
+  subspacesEnabled: boolean;
   splitWorkspaceCompatibility?: boolean;
   preventSelectingAllSubspaces?: boolean;
   subspaceNames: string[];
@@ -40,10 +40,10 @@ export class SubspacesConfiguration {
    */
   public readonly subspaceJsonFilePath: string;
 
-  /**
+  /*
    * Determines if the subspace feature is enabled
    */
-  public readonly enabled: boolean;
+  public readonly subspacesEnabled: boolean;
 
   /**
    * This determines if the subspaces feature supports adding configuration files under the project folder itself
@@ -62,12 +62,12 @@ export class SubspacesConfiguration {
 
   private constructor(configuration: Readonly<ISubspacesConfigurationJson>, subspaceJsonFilePath: string) {
     this.subspaceJsonFilePath = subspaceJsonFilePath;
-    this.enabled = configuration.enabled;
+    this.subspacesEnabled = configuration.subspacesEnabled;
     this.splitWorkspaceCompatibility = !!configuration.splitWorkspaceCompatibility;
     this.preventSelectingAllSubspaces = !!configuration.preventSelectingAllSubspaces;
     const subspaceNames: Set<string> = new Set();
     for (const subspaceName of configuration.subspaceNames) {
-      SubspacesConfiguration.requireValidSubspaceName(subspaceName, this.enabled);
+      SubspacesConfiguration.requireValidSubspaceName(subspaceName, this.subspacesEnabled);
 
       subspaceNames.add(subspaceName);
     }

--- a/libraries/rush-lib/src/schemas/subspaces.schema.json
+++ b/libraries/rush-lib/src/schemas/subspaces.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Rush subspace config file.",
-  "description": "The configuration file for enabling the subspaces feature in rush. This is an EXPERIMENTAL feature which is not yet fully implemented. To opt into the experiemnt, simply toggle the 'enabled' property in this file.",
+  "description": "The configuration file for enabling the subspaces feature in rush. This is an EXPERIMENTAL feature which is not yet fully implemented. To opt into the experiment, simply toggle the 'enabled' property in this file.",
   "type": "object",
 
   "properties": {
@@ -9,7 +9,7 @@
       "description": "Part of the JSON Schema standard, this optional keyword declares the URL of the schema that the file conforms to. Editors may download the schema and use it to perform syntax highlighting.",
       "type": "string"
     },
-    "enabled": {
+    "subspacesEnabled": {
       "description": "If true, rush will use the subspaces configuration.",
       "type": "boolean"
     },


### PR DESCRIPTION
## Summary

1. `subspacesEnabled` is more consistent with other settings such as `buildCacheEnabled` and `cobuildFeatureEnabled`
2. An explicit name is easier to discuss in the documentation ( *"This feature requires subspacesEnabled=true"* versus *"This feature requires enabled=true in your subspaces.json file"* )